### PR TITLE
Add a translation of weak type information.

### DIFF
--- a/naming/promote-clear-usage.md
+++ b/naming/promote-clear-usage.md
@@ -92,7 +92,7 @@ protocol IteratorProtocol { ... }
 
 
 
-### **파라미터의 역할을 드러내기 위해 weak type information을** 보충하세요&#x20;
+### **파라미터의 역할을 명확히 하기 위해 불충분한 type 정보를** 보충하세요&#x20;
 
 (번역이 약간 어색한데, 예제를 보면 더 빨리 이해할 수 있을 것 같아요)
 
@@ -106,7 +106,7 @@ func add(_ observer: NSObject, for keyPath: String)
 grid.add(self, for: graphics) // 애매함
 ```
 
-명확하게 하려면, weakly typed parameter 앞에 그것의 역할을 명시하세요.
+명확하게 하려면, type 자체에서 많은 정보 얻을 수 없는 parameter 앞에 그것의 역할을 명시하세요.
 
 #### Good
 


### PR DESCRIPTION
안녕하세요, 인프런에서 "읽기 좋은 코드 작성하기" 강의 잘 수강하고 있습니다~
그 중 'Promote Clear Usage 4 - 파라미터의 역할 드러내기' 챕터에서 weakly typed parameter 라는 단어가 나오길래 "이게 뭐지,, weak type 이라고 내가 모르는 새로운 타입이 생겼나??🤔" 라는 생각이 들어 API Design Guidelines 원문을 찾아보게 되었고, `weak type` 을 **타입 자체에서 추론할 수 있는 정보가 많지 않는 type** 정도로 의역을 하면 이해하기 더 쉽지 않을까 생각이 들어 pr 올려봅니다!
한번 검토해주시면 감사하겠습니다 🙋🏻‍♀️