### PR TITLE
프로토콜 번역 누락된 부분 추가하였습니다. 

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -11,7 +11,7 @@
 
 ## Conventions
 
-* [🏳🌈 🏳🌈 General Conventions](conventions/general-conventions.md)
+* [🌈 General Conventions](conventions/general-conventions.md)
 * [📥 Parameters](conventions/parameters.md)
 * [🏷 Argument Labels](conventions/argument-labels.md)
 

--- a/conventions/parameters.md
+++ b/conventions/parameters.md
@@ -9,7 +9,7 @@ func move(from start: Point, to end: Point)
 - 파라미터 이름은 function 이나 method를 사용하는 곳에서 보이지 않지만, function 이나 method를 설명해주는 역할을 갖습니다.
 - 문서(주석)를 읽기에 쉬운 파라미터 이름을 사용하세요.
 
-### Good
+#### Good
 
 이런 이름들은 주석을 읽기 쉽게 해줍니다.
 (아래 예제에서 `predicate` 와 `subRange` `newElements` 에 해당하는 내용)
@@ -23,7 +23,7 @@ func filter(_ predicate: (Element) -> Bool) -> [Generator.Element]
 mutating func replaceRange(_ subRange: Range, with newElements: [E])
 ```
 
-### Bad
+#### Bad
 
 ```swift
 /// Return an `Array` containing the elements of `self`
@@ -53,7 +53,7 @@ let order = lastName.compare(royalFamilyName)
 - default parameters는 일반적인 method families를 사용하는 것보다 선호됩니다. (기본 파라미터 사용 > 기본 파라미터 안쓰고 method 여러개 나열 하는 것) 
 - 왜냐하면 API를 이해하려고 노력하는 사람들이 신경써야할 부분을 줄여주기 때문입니다. (아래 예제를 보면 조금 더 이해가 쉽습니다.)
 
-### Good
+#### Good
 
 ```swift
 extension String {
@@ -65,7 +65,7 @@ extension String {
 }
 ```
 
-### Bad
+#### Bad
 
 ```swift
 extension String {

--- a/naming/strive-for-fluent-usage.md
+++ b/naming/strive-for-fluent-usage.md
@@ -97,10 +97,11 @@ let rgbForeground = RGBColor(cmykForeground)
 
 ### nonmutating인 Boolean 메소드와 프로퍼티는 호출되는 객체에 대한 주장문처럼 읽혀야 한다
 
-
 eg. `x.isEmpty` , `line1.intersects(line2)`&#x20;
 
+### 어떤 것이 무엇인지를 설명하는 프로토콜은 명사로 읽혀야 합니다
 
+eg. `Collection`&#x20;
 
 ### 능력을 설명하는 프로토콜은 able, ible, ing를 사용한 접미사로 네이밍해야 합니다
 


### PR DESCRIPTION
https://www.swift.org/documentation/api-design-guidelines/#strive-for-fluent-usage